### PR TITLE
use meldoic-devel for kinetic/lunar release

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -60,7 +60,7 @@ tracks:
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
-    devel_branch: kinetic-devel
+    devel_branch: melodic-devel
     last_version: 1.12.2
     name: pr2_common
     patches: null

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -84,7 +84,7 @@ tracks:
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
-    devel_branch: kinetic-devel
+    devel_branch: melodic-devel
     last_version: 1.12.2
     name: pr2_common
     patches: null


### PR DESCRIPTION
@knorth55 thank you for contribution https://github.com/PR2/pr2_common/pull/276
Since I forget to  update the version number of the melodic release, current melodic uses 1.12.4 and kinetic uses 1.12.2, I think we are not able to release kinetic with 1.12.3
So my proposal here is to releases 1.12.4 for kinetic/lunar and closes

let me know your thoughts

C.f. https://github.com/PR2/pr2_common/pull/276